### PR TITLE
use eo indexing

### DIFF
--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -128,7 +128,6 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
                    solver_params.compression_type);
     
     /*
-    /*
     spinor** tempE;
     init_solver_field(&tempE, VOLUMEPLUSRAND/2, 1);
     
@@ -158,7 +157,7 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
                    solver_params.sloppy_precision,
                    solver_params.compression_type);
     */
-     mul_gamma5(P, VOLUME/2);
+    mul_gamma5(P, VOLUME/2);
     // finalize_solver(tempE,1);
 
   } else


### PR DESCRIPTION
use 'eo_idx = tm_idx/2' when writing to or reading from tmLQCD eo spinors. The residual is still wrong, however. Support both parities in 'reorder_eo_spinor_[to/from]Quda'.

@Marcogarofalo unfortunately this does not resolve the issue with the residual but it should be correct in principle, so there must be some subtlety that we're missing (perhaps a field normalisation)