### PR TITLE
use Qtm_plus_psi explicitly for now to make things simpler

### DIFF
--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1081,12 +1081,14 @@ void D_psi_quda(spinor * const P, spinor * const Q) {
 void M_quda(spinor * const P, spinor * const Q) {
 
   _initQuda();
+
   inv_param.kappa = g_kappa;
   // IMPORTANT: use opposite TM flavor since gamma5 -> -gamma5 (until LXLYLZT prob. resolved)
   inv_param.mu = -g_mu;
   inv_param.epsilon = 0.0;
 
   inv_param.twist_flavor = QUDA_TWIST_SINGLET;
+  inv_param.preserve_source = QUDA_PRESERVE_SOURCE_YES;
   inv_param.Ls = (inv_param.twist_flavor == QUDA_TWIST_NONDEG_DOUBLET ) ? 2 : 1;
   //inv_param.Ls=1;
   //custom
@@ -1112,7 +1114,7 @@ void M_quda(spinor * const P, spinor * const Q) {
   // multiply
 
   
-  MatQuda( spinorOut, spinorIn, &inv_param);
+  MatQuda(spinorOut, spinorIn, &inv_param);
 
   // reorder spinor
   reorder_spinor_eo_fromQuda( (double*)spinorIn,  inv_param.cpu_prec, 0, 1);


### PR DESCRIPTION
A little progress, thanks.

```
ix=0
 tmLQCD=(2.655e-04,-2.917e-18,-3.032e-18), (1.996e-18,-4.307e-18,3.469e-18), (3.855e-18,0.000e+00,0.000e+00), (0.000e+00,-5.456e-18,-1.000e+00) 
 quda=(-3.063e-18,-2.655e-04,-1.647e-02), (-2.475e-02,-3.910e-02,2.857e-02), (-2.911e-03,1.140e-34,8.146e-37), (-3.619e-35,5.298e-18,-1.000e+00)  
ix=1
 tmLQCD=(-8.053e-03,0.000e+00,0.000e+00), (0.000e+00,-9.352e-03,-5.811e-02), (-6.216e-02,0.000e+00,0.000e+00), (0.000e+00,-1.188e-02,1.470e-02) 
 quda=(-1.055e-02,-4.528e-18,-2.597e-19), (1.217e-18,6.463e-18,-2.237e-17), (3.099e-18,-0.000e+00,-0.000e+00), (-0.000e+00,-1.188e-02,1.470e-02)  
ix=2
 tmLQCD=(2.944e-02,-2.588e-03,3.090e-02), (1.262e-02,3.305e-03,1.660e-03), (-2.243e-02,-9.416e-03,-8.240e-03), (-5.583e-03,-3.669e-03,2.974e-02) 
 quda=(7.662e-03,5.465e-03,1.419e-02), (-6.899e-03,4.140e-03,-2.810e-02), (-1.781e-02,-5.222e-03,2.693e-02), (1.285e-02,-6.458e-04,7.613e-03)  
ix=3
 tmLQCD=(1.587e-02,-3.555e-02,2.596e-02), (1.375e-02,4.413e-03,1.396e-02), (-5.063e-03,4.580e-03,2.645e-02), (5.757e-03,-3.714e-02,1.881e-02) 
 quda=(1.363e-02,-8.346e-03,-2.337e-02), (-1.340e-02,3.625e-02,-2.429e-02), (-1.048e-02,-3.784e-02,1.714e-02), (1.036e-02,6.470e-04,1.704e-02)  
ix=4
 tmLQCD=(-2.210e-02,2.944e-02,-1.725e-02), (7.671e-02,0.000e+00,0.000e+00), (0.000e+00,0.000e+00,0.000e+00), (0.000e+00,1.094e-02,-4.008e-02) 
 quda=(-3.124e-02,0.000e+00,0.000e+00), (0.000e+00,0.000e+00,0.000e+00), (0.000e+00,-6.976e-19,-2.150e-19), (2.009e-18,1.094e-02,-4.008e-02)  
ix=5
 tmLQCD=(2.049e-03,0.000e+00,0.000e+00), (0.000e+00,0.000e+00,0.000e+00), (0.000e+00,0.000e+00,0.000e+00), (0.000e+00,0.000e+00,0.000e+00) 
 quda=(0.000e+00,-2.944e-02,1.725e-02), (-7.671e-02,-2.653e-19,-8.237e-19), (-6.764e-19,-0.000e+00,-0.000e+00), (-0.000e+00,-0.000e+00,-0.000e+00)  
[...]
```

I'm afraid this requires some pen & paper to figure out if we need to adjust the gamma basis (and / or ordering of links) to make working directly on the odd sub-lattice work.