### PR TITLE
format string in spinor comparison was missing one placeholder

### DIFF
--- a/solver/monomial_solve.c
+++ b/solver/monomial_solve.c
@@ -174,15 +174,18 @@ int solve_degenerate(spinor * const P, spinor * const Q, solver_params_t solver_
       spinor *hp=(spinor*) temp[0]+ix;
       spinor *dp=(spinor*) P+ix;
       double r= creal((hp+ix)->s0.c0)-creal((dp+ix)->s0.c0);
-      printf("ix=%d\n tmLQCD=(%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e) \n quda=(%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e)  \n",ix,r,
-      creal((hp)->s0.c0), creal((hp)->s0.c1), creal((hp)->s0.c2),
-      creal((hp)->s1.c0), creal((hp)->s1.c1), creal((hp)->s1.c2),
-      creal((hp)->s2.c0), creal((hp)->s2.c1), creal((hp)->s2.c2),
-      creal((hp)->s3.c0), creal((hp)->s3.c1), creal((hp)->s3.c2),
-      creal((dp)->s0.c0), creal((dp)->s0.c1), creal((dp)->s0.c2),
-      creal((dp)->s1.c0), creal((dp)->s1.c1), creal((dp)->s1.c2),
-      creal((dp)->s2.c0), creal((dp)->s2.c1), creal((dp)->s2.c2),
-      creal((dp)->s3.c0), creal((dp)->s3.c1), creal((dp)->s3.c2)
+      printf("ix=%d, r=%.3e\n"
+             "tmLQCD=(%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e)\n"
+             "quda=(%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e), (%.3e,%.3e,%.3e)  \n",
+               ix,r,
+               creal((hp)->s0.c0), creal((hp)->s0.c1), creal((hp)->s0.c2),
+               creal((hp)->s1.c0), creal((hp)->s1.c1), creal((hp)->s1.c2),
+               creal((hp)->s2.c0), creal((hp)->s2.c1), creal((hp)->s2.c2),
+               creal((hp)->s3.c0), creal((hp)->s3.c1), creal((hp)->s3.c2),
+               creal((dp)->s0.c0), creal((dp)->s0.c1), creal((dp)->s0.c2),
+               creal((dp)->s1.c0), creal((dp)->s1.c1), creal((dp)->s1.c2),
+               creal((dp)->s2.c0), creal((dp)->s2.c1), creal((dp)->s2.c2),
+               creal((dp)->s3.c0), creal((dp)->s3.c1), creal((dp)->s3.c2)
        );
     }
     print_spinor_similar_components(temp[0], P, VOLUME/2, 1e-4);


### PR DESCRIPTION
I missed the `r` variable yesterday, that's why there were similar elements, one of the placeholders was missing in the format string.