### PR TITLE
some work to make the MG work more or less reliably in the HMC

### DIFF
--- a/default_input_values.h
+++ b/default_input_values.h
@@ -115,6 +115,7 @@
 #define _default_g_eps_sq_force3 -1.
 #define _default_g_eps_sq_acc3 -1.
 #define _default_g_relative_precision_flag 0
+#define _default_g_strict_residual_check 0
 #define _default_return_check_flag 0
 #define _default_return_check_interval 100
 #define _default_g_debug_level 1
@@ -208,6 +209,7 @@
 
 /* default input values for QUDA interface */
 /* These follow the recommendations of https://github.com/lattice/quda/wiki/Multigrid-Solver */
+#define _default_quda_mg_setup_2kappamu 0.0
 #define _default_quda_mg_n_level 2
 #define _default_quda_mg_n_vec 24
 #define _default_quda_mg_mu_factor 1.0
@@ -220,8 +222,11 @@
 #define _default_quda_mg_nu_post 4
 #define _default_quda_mg_omega 0.85
 #define _default_quda_mg_enable_size_three_blocks 0
+// by default, we always reset the MG setup
+// in the HMC, this needs to be set to a reasonable value
+// depending on the length of the integration step
 #define _default_quda_mg_reset_setup_threshold 2*DBL_EPSILON
-#define _default_quda_mg_reset_setup_mu_threshold 2*DBL_EPSILON
+#define _default_quda_mg_reuse_setup_mu_threshold 2*DBL_EPSILON
 
 // gradient flow measurement step size and maximum flow time
 #define _default_gf_eps 0.01

--- a/global.h
+++ b/global.h
@@ -74,6 +74,7 @@ EXTERN int NO_OF_BISPINORFIELDS;
 EXTERN int g_update_gauge_copy;
 EXTERN int g_update_gauge_copy_32;
 EXTERN int g_relative_precision_flag;
+EXTERN int g_strict_residual_check;
 EXTERN int g_debug_level;
 EXTERN int g_disable_IO_checks;
 EXTERN int g_disable_src_IO_checks;

--- a/hmc_tm.c
+++ b/hmc_tm.c
@@ -325,7 +325,6 @@ int main(int argc,char *argv[]) {
     
   /*Convert to a 32 bit gauge field, after xchange*/
   convert_32_gauge_field(g_gauge_field_32, g_gauge_field, VOLUMEPLUSRAND + g_dbw2rand);
-  update_tm_gauge_id(&g_gauge_state_32, TM_GAUGE_PROPAGATE_THRESHOLD);
 #ifdef TM_USE_MPI
   update_tm_gauge_exchange(&g_gauge_state_32);
 #endif

--- a/invert.c
+++ b/invert.c
@@ -310,7 +310,6 @@ int main(int argc, char *argv[])
 #endif
     /*Convert to a 32 bit gauge field, after xchange*/
     convert_32_gauge_field(g_gauge_field_32, g_gauge_field, VOLUMEPLUSRAND);
-    update_tm_gauge_id(&g_gauge_state_32, TM_GAUGE_PROPAGATE_THRESHOLD);
     update_tm_gauge_exchange(&g_gauge_state_32);
 
     /*compute the energy of the gauge field*/

--- a/misc_types.h
+++ b/misc_types.h
@@ -40,8 +40,13 @@
 #include "tm_debug_printf.h"
 
 #define TM_GAUGE_FIELD_NAME_LENGTH 100
-#define TM_GAUGE_PROPAGATE_THRESHOLD 10.0
-#define TM_GAUGE_PROPAGATE_MIN 0.01
+
+// this number is completely arbitrary, but it's supposed to make sure that
+// for example the QUDA MG setup is reset when a trajectory was rejected in the HMC 
+#define TM_GAUGE_PROPAGATE_THRESHOLD 3.0
+// this number is used to advance the state of the gauge field when SU3-restoration
+// is done
+#define TM_GAUGE_PROPAGATE_MIN 0.001
 
 /* enumeration type for the identity of the program
  * which is being executed

--- a/operator.c
+++ b/operator.c
@@ -518,6 +518,21 @@ void op_invert(const int op_id, const int index_start, const int write_prop) {
     if(write_prop) optr->write_prop(op_id, index_start, 0);
   }
   etime = gettime();
+
+  if( g_strict_residual_check ){
+    double rel_nrm = optr->rel_prec ? (square_norm(optr->sr0, VOLUME/2, 1) + square_norm(optr->sr1, VOLUME/2, 1)) : 1.0;
+    if( optr->type == DBTMWILSON || optr->type == DBCLOVER ){
+      rel_nrm += optr->rel_prec ? (square_norm(optr->sr2, VOLUME/2, 1) + square_norm(optr->sr3, VOLUME/2, 1)) : 1.0;
+    }
+    if( optr->eps_sq < 1.5*( optr->reached_prec / rel_nrm ) ){
+      fprintf(stdout, "# Inversion done in %d iterations, squared residue = %e!\n",
+              optr->iterations, optr->reached_prec);
+      fprintf(stdout, "# Inversion done in %1.2e sec. \n", etime - atime);
+      fflush(stdout);
+      fatal_error("Reached precision larger that target precision by a factor of more than 1.5!", "op_invert");
+    }
+  } 
+
   if (g_cart_id == 0 && g_debug_level > 0) {
     fprintf(stdout, "# Inversion done in %d iterations, squared residue = %e!\n",
             optr->iterations, optr->reached_prec);

--- a/read_input.l
+++ b/read_input.l
@@ -532,6 +532,7 @@ static inline double fltlist_next_token(int * const list_end){
 %x PROPSPLIT
 %x NOSAMPLES
 %x RELPREC
+%x STRICTRESIDUALCHECK
 %x REVCHECK
 %x REVINT
 %x DEBUG
@@ -685,6 +686,7 @@ static inline double fltlist_next_token(int * const list_end){
 ^ThetaZ{EQL}                       BEGIN(BOUNDZ);
 ^ReadSource{EQL}                   BEGIN(READSOURCE);
 ^UseRelativePrecision{EQL}         BEGIN(RELPREC);
+^StrictResidualCheck{EQL}          BEGIN(STRICTRESIDUALCHECK);
 ^ReversibilityCheck{EQL}           BEGIN(REVCHECK);
 ^ReversibilityCheckIntervall{EQL}  BEGIN(REVINT);
 ^DebugLevel{EQL}                   BEGIN(DEBUG);
@@ -1781,6 +1783,11 @@ static inline double fltlist_next_token(int * const list_end){
     }
     free(input_copy);
   }
+  {SPC}*MGSetup2KappaMu{EQL}{FLT}+ {
+    sscanf(yytext, " %[a-zA-Z2] = %lf", name, &c);
+    quda_input.mg_setup_2kappamu = c;
+    if(myverbose) printf("  MGSetup2KappaMu set to %e line %d\n", quda_input.mg_setup_2kappamu, line_of_file);
+  }
   {SPC}*MGSetupSolver{EQL}cg {
     quda_input.mg_setup_inv_type = QUDA_CG_INVERTER;
     if(myverbose) printf("  MGSetupSolver set to CG line %d\n", line_of_file);
@@ -1845,10 +1852,10 @@ static inline double fltlist_next_token(int * const list_end){
     quda_input.mg_enable_size_three_blocks = 0;
     if(myverbose) printf("  MGEnableSizeThreeBlocks set to NO in line %d\n", line_of_file);
   }
-  {SPC}*MGResetSetupMuThreshold{EQL}{FLT}+ {
+  {SPC}*MGReuseSetupMuThreshold{EQL}{FLT}+ {
     sscanf(yytext, " %[a-zA-Z] = %lf", name, &c);
-    quda_input.mg_reset_setup_mu_threshold = c;
-    if(myverbose) printf("  MGResetSetupMuThreshold set to %f line %d\n", quda_input.mg_reset_setup_mu_threshold, line_of_file);
+    quda_input.mg_reuse_setup_mu_threshold = c;
+    if(myverbose) printf("  MGReuseSetupMuThreshold set to %f line %d\n", quda_input.mg_reuse_setup_mu_threshold, line_of_file);
   }
   {SPC}*MGResetSetupThreshold{EQL}{FLT}+ {
     sscanf(yytext, " %[a-zA-Z] = %lf", name, &c);
@@ -3301,6 +3308,14 @@ static inline double fltlist_next_token(int * const list_end){
   g_relative_precision_flag = 0;
   if(myverbose!=0) printf("Using absolute precision\n");
 }
+<STRICTRESIDUALCHECK>yes {
+  g_strict_residual_check = 1;
+  if(myverbose!=0) printf("g_strict_residual_check = %d!\n", g_strict_residual_check);
+}
+<STRICTRESIDUALCHECK>no {
+  g_strict_residual_check = 0;
+  if(myverbose!=0) printf("g_strict_residual_check = %d!\n", g_strict_residual_check);
+}
 <REVCHECK>yes {
   return_check_flag = 1;
   if(myverbose!=0) printf("Perform checks of Reversibility\n");
@@ -3637,6 +3652,7 @@ int read_input(char * conf_file){
   PropInfo.splitted = _default_propagator_splitted;
   SourceInfo.splitted = _default_source_splitted;
   g_relative_precision_flag = _default_g_relative_precision_flag;
+  g_strict_residual_check = _default_g_strict_residual_check;
   return_check_flag = _default_return_check_flag;
   return_check_interval = _default_return_check_interval;
   g_debug_level = _default_g_debug_level;
@@ -3691,8 +3707,9 @@ int read_input(char * conf_file){
   quda_input.fermionbc = TM_QUDA_THETABC;
   quda_input.pipeline = 0;
   quda_input.gcrNkrylov = 10;
-  quda_input.reliable_delta = 1e-5;
+  quda_input.reliable_delta = 1e-3; // anything smaller than this and we break down in double-half
   quda_input.mg_n_level = _default_quda_mg_n_level;
+  quda_input.mg_setup_2kappamu = _default_quda_mg_setup_2kappamu;
   for( int level = 0; level < QUDA_MAX_MG_LEVEL; ++level){
     quda_input.mg_verbosity[level] = QUDA_SILENT;
     quda_input.mg_omega[level] = _default_quda_mg_omega;
@@ -3745,7 +3762,7 @@ int read_input(char * conf_file){
   quda_input.mg_run_verify = QUDA_BOOLEAN_YES;
   quda_input.mg_enable_size_three_blocks = _default_quda_mg_enable_size_three_blocks;
   quda_input.mg_reset_setup_threshold = _default_quda_mg_reset_setup_threshold;
-  quda_input.mg_reset_setup_mu_threshold = _default_quda_mg_reset_setup_mu_threshold;
+  quda_input.mg_reuse_setup_mu_threshold = _default_quda_mg_reuse_setup_mu_threshold;
   quda_input.mg_run_low_mode_check = QUDA_BOOLEAN_NO;
   quda_input.mg_run_oblique_proj_check = QUDA_BOOLEAN_NO; 
 

--- a/update_momenta_fg.c
+++ b/update_momenta_fg.c
@@ -165,6 +165,12 @@ void update_momenta_fg(int * mnllist, double step, const int no,
 #ifdef DDalphaAMG
      MG_update_gauge(0.0);
 #endif
+   
+   // ensure that the QUDA MG setup is updated
+   update_tm_gauge_id(&g_gauge_state, step_fg);
+   update_tm_gauge_id(&g_gauge_state_32, step_fg);
+   update_tm_gauge_exchange(&g_gauge_state);
+   update_tm_gauge_exchange(&g_gauge_state_32);
 
    /*Convert to a 32 bit gauge field, after xchange*/
    convert_32_gauge_field(g_gauge_field_32, hf->gaugefield, VOLUMEPLUSRAND + g_dbw2rand);
@@ -204,6 +210,11 @@ void update_momenta_fg(int * mnllist, double step, const int no,
 #ifdef DDalphaAMG
   MG_update_gauge(0.0);
 #endif
+   
+  update_tm_gauge_id(&g_gauge_state, -step_fg);
+  update_tm_gauge_id(&g_gauge_state_32, -step_fg);
+  update_tm_gauge_exchange(&g_gauge_state);
+  update_tm_gauge_exchange(&g_gauge_state_32);
 
   /*Convert to a 32 bit gauge field, after xchange*/
   convert_32_gauge_field(g_gauge_field_32, hf->gaugefield, VOLUMEPLUSRAND + g_dbw2rand);

--- a/update_tm.c
+++ b/update_tm.c
@@ -304,6 +304,8 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
       if(g_proc_id == 0 && g_debug_level > 0) {
         fprintf(stdout, "# Reading done.\n");
       }
+      // when we've read back the gauge field, we do a large step
+      update_tm_gauge_id(&g_gauge_state, TM_GAUGE_PROPAGATE_THRESHOLD);
       update_tm_gauge_id(&g_gauge_state_32, TM_GAUGE_PROPAGATE_THRESHOLD);
     }
     if(g_proc_id == 0) {
@@ -328,6 +330,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
     }
     // su3 restoration should also trigger the updated gauge field to be
     // propagated, but we're not too harsh here
+    // FIXME: this may need more thought
     update_tm_gauge_id(&g_gauge_state, TM_GAUGE_PROPAGATE_MIN);
     update_tm_gauge_id(&g_gauge_state_32, TM_GAUGE_PROPAGATE_MIN);
   }
@@ -342,7 +345,7 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
         _su3_assign(*v,*w);
       }
     }
-    // by default we use a very large step here to make sure that any checks
+    // by default we use a large step here to make sure that any checks
     // will result in the updated gauge field to be propagated
     update_tm_gauge_id(&g_gauge_state, TM_GAUGE_PROPAGATE_THRESHOLD);
     update_tm_gauge_id(&g_gauge_state_32, TM_GAUGE_PROPAGATE_THRESHOLD);
@@ -360,7 +363,9 @@ int update_tm(double *plaquette_energy, double *rectangle_energy,
   
   /*Convert to a 32 bit gauge field, after xchange*/
   convert_32_gauge_field(g_gauge_field_32, hf.gaugefield, VOLUMEPLUSRAND + g_dbw2rand);
+#ifdef TM_USE_MPI
   update_tm_gauge_exchange(&g_gauge_state_32);
+#endif
   
   etime=gettime();
 


### PR DESCRIPTION
- introduce StrictResidualCheck parameter which allows for residuals to
be checked in the HMC (only solve_degenerate for now) and op_invert
- introduce MGSetup2KappaMu parameter for QUDA MG input params to
specify a particul mu value that the setup should be performed with
- fix a few bugs in the tracking of the gauge field to make sure
that the QUDA MG setup is always up to date
- track the state of the gauge field in the 2MNFG integrator

With these changes, the following input file will run but one encounters https://github.com/etmc/tmLQCD/issues/494

```
L=16
T=32
Measurements = 1000
#StartCondition = hot
StartCondition = continue
InitialStoreCounter = readin
2KappaMu = 0.002
kappa = 0.170
NSave = 500000
ThetaT = 1.0
UseEvenOdd = yes
ReversibilityCheck = no
ReversibilityCheckIntervall = 100
DebugLevel = 3
ompnumthreads = 6

StrictResidualCheck = yes

BeginExternalInverter QUDA
  Pipeline = 10
  gcrNkrylov = 20
  MGCoarseMuFactor = 1.0, 1.0, 20.0
  MGNumberOfLevels = 3
  MGNumberOfVectors = 24, 24, 24
  MGSetupSolver = cg
  MGSetup2KappaMu = 0.003
  MGVerbosity = summarize, summarize, summarize
  MGVerbosity = silent, silent, silent
  MGSetupSolverTolerance = 5e-7, 5e-7, 5e-7
  MGSetupMaxSolverIterations = 1500, 1500, 1500
  MGCoarseSolverType = gcr, gcr, cagcr
  MgCoarseSolverTolerance = 0.2, 0.2, 0.2
  MGCoarseMaxSolverIterations = 10, 10, 10
  MGSmootherType = cagcr, cagcr, cagcr
  MGSmootherTolerance = 0.1, 0.1, 0.1
  MGSmootherPreIterations = 0, 0, 0
  MGSmootherPostIterations = 4, 4, 4
  MGBlockSizesX = 4,2
  MGBlockSizesY = 4,2
  MGBlockSizesZ = 4,2
  MGBlockSizesT = 4,2
  MGOverUnderRelaxationFactor = 0.90, 0.90, 0.90
  # when the step in the gauge field is too large, we have to rerun the setup
  # for the solver to not break down
  # here we specify the maximum step size for which we attempt an update instead
  # of a reset
  MGResetSetupThreshold = 0.051
EndExternalInverter

# note by BaKo: 
#   online measurements currently lead to residual violations
#   which are currently unclear to me
#
# BeginMeasurement CORRELATORS
#   Frequency = 1
# EndMeasurement

BeginMonomial GAUGE
  Type = Wilson
  beta = 6.00
  Timescale = 0
EndMonomial

BeginMonomial DET
  Timescale = 1
  2KappaMu = 0.3
  kappa = 0.170
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 500
  Name = det
  UseExternalInverter = QUDA
  solver = cg
  usesloppyprecision = half
EndMonomial

BeginMonomial DETRATIO
  Timescale = 2
  2KappaMu = 0.03
  kappa = 0.170
  2KappaMu2 = 0.3
  kappa2 = 0.170
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 2000
  Name = detratio1
  UseExternalInverter = QUDA
  solver = cg
  usesloppyprecision = half
EndMonomial

BeginMonomial DETRATIO
  Timescale = 3
  2KappaMu = 0.003
  kappa = 0.170
  2KappaMu2 = 0.03
  kappa2 = 0.170
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 10000
  Name = detratio2
  UseExternalInverter = QUDA
  Solver = mg
  UseSloppyPrecision = single
EndMonomial

BeginIntegrator 
  Type0 = 2MN #FG
  Type1 = 2MN #FG
  Type2 = 2MN #FG
  Type3 = 2MN #FG
  IntegrationSteps0 = 1
  IntegrationSteps1 = 1
  IntegrationSteps2 = 1 
  IntegrationSteps3 = 10
  Tau = 1.0
  Lambda0 = 0.19
  Lambda1 = 0.20
  Lambda2 = 0.205
  Lambda3 = 0.210
  NumberOfTimescales = 4
EndIntegrator
```