### PR TITLE
add mechansim to ensure that the QUDA MG setup is reset regularly

### DIFF
--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1358,6 +1358,7 @@ void _setOneFlavourSolverParam(const double kappa, const double c_sw, const doub
       
       inv_param.preconditioner = quda_mg_preconditioner;
       set_quda_mg_setup_state(&quda_mg_setup_state, &quda_gauge_state);
+      set_quda_mg_setup_init_gauge_id(&quda_mg_setup_state, &quda_gauge_state);
       tm_debug_printf(0,1,"# TM_QUDA: MG Preconditioner Setup took %.3f seconds\n", gettime()-atime);
     } else if ( check_quda_mg_setup_state(&quda_mg_setup_state, &quda_gauge_state, &quda_input) == TM_QUDA_MG_SETUP_UPDATE )  {
       tm_debug_printf(0,0,"# TM_QUDA: Updating MG Preconditioner Setup for gauge %f\n", quda_gauge_state.gauge_id);

--- a/quda_types.h
+++ b/quda_types.h
@@ -111,6 +111,7 @@ typedef struct tm_QudaParams_t {
 } tm_QudaParams_t;
 
 typedef struct tm_QudaMGSetupState_t {
+  double init_gauge_id;
   double gauge_id;
   double c_sw;
   double kappa;
@@ -219,7 +220,8 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
       ( fabs(quda_mg_setup_state->theta_y - quda_gauge_state->theta_y) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_z - quda_gauge_state->theta_z) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_t - quda_gauge_state->theta_t) > 2*DBL_EPSILON ) || 
-      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) > quda_params->mg_reset_setup_threshold ) ){
+      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) > quda_params->mg_reset_setup_threshold ) ||
+      ( fabs(quda_mg_setup_state->init_gauge_id - quda_gauge_state->gauge_id) > quda_params->mg_reset_setup_threshold ) ){
     return TM_QUDA_MG_SETUP_RESET;
   // in other cases, e.g., when the operator parameters change or if the gauge_id has "moved" only a little,
   // we don't need to redo the setup, we can simply rebuild the coarse operators with the
@@ -238,6 +240,11 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
   }
 }
 
+static inline void set_quda_mg_setup_init_gauge_id(tm_QudaMGSetupState_t * const quda_mg_setup_state,
+                                                   const tm_QudaGaugeState_t * const quda_gauge_state){
+  quda_mg_setup_state->init_gauge_id = quda_gauge_state->gauge_id;
+}
+
 static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg_setup_state,
                                            const tm_QudaGaugeState_t * const quda_gauge_state){
   quda_mg_setup_state->gauge_id = quda_gauge_state->gauge_id;
@@ -252,6 +259,7 @@ static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg
 }
 
 static inline void reset_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg_setup_state){
+  quda_mg_setup_state->init_gauge_id = -1;
   quda_mg_setup_state->gauge_id = -1;
   quda_mg_setup_state->initialised = 0;
   quda_mg_setup_state->mu = -1.0;

--- a/update_momenta_fg.c
+++ b/update_momenta_fg.c
@@ -230,7 +230,7 @@ void update_momenta_fg(int * mnllist, double step, const int no,
 
   etime = gettime();
   if(g_debug_level > 1 && g_proc_id == 0) {
-    printf("# Time gauge update: %e s\n", etime-atime); 
+    printf("# Time force-gradient gauge update: %e s\n", etime-atime); 
   } 
   return;
 }


### PR DESCRIPTION
to be set via the MGResetSetupThreshold parameter in the QUDA ExternalInverter section

This nf=4 twisted mass run (roughly at maximal twist) works rather nicely with this setup.

```
L=16
T=32
Measurements = 1000
#StartCondition = hot
StartCondition = continue
InitialStoreCounter = readin
2KappaMu = 0.002
kappa = 0.163255
NSave = 500000
ThetaT = 1.0
UseEvenOdd = yes
ReversibilityCheck = no
ReversibilityCheckIntervall = 100
DebugLevel = 3
ompnumthreads = 6

StrictResidualCheck = yes

BeginExternalInverter QUDA
  Pipeline = 10
  gcrNkrylov = 20
  MGCoarseMuFactor = 1.0, 1.0, 20.0
  MGNumberOfLevels = 3
  MGNumberOfVectors = 24, 24, 24
  MGSetupSolver = cg
  MGSetup2KappaMu = 0.002
  MGVerbosity = summarize, summarize, summarize
  MGVerbosity = silent, silent, silent
  MGSetupSolverTolerance = 5e-7, 5e-7, 5e-7
  MGSetupMaxSolverIterations = 1500, 1500, 1500
  MGCoarseSolverType = gcr, gcr, cagcr
  MgCoarseSolverTolerance = 0.2, 0.2, 0.2
  MGCoarseMaxSolverIterations = 10, 10, 10
  MGSmootherType = cagcr, cagcr, cagcr
  MGSmootherTolerance = 0.1, 0.1, 0.1
  MGSmootherPreIterations = 0, 0, 0
  MGSmootherPostIterations = 4, 4, 4
  MGBlockSizesX = 4,2
  MGBlockSizesY = 4,2
  MGBlockSizesZ = 4,2
  MGBlockSizesT = 4,2
  MGOverUnderRelaxationFactor = 0.90, 0.90, 0.90
  # when the step in the gauge field is too large, we have to rerun the setup
  # for the solver to not break down
  # here we specify the maximum step size for which we attempt an update instead
  # of a reset
  MGResetSetupThreshold = 0.201
EndExternalInverter

# note by BaKo: 
#   online measurements currently lead to residual violations
#   which are currently unclear to me
#
# BeginMeasurement CORRELATORS
#   Frequency = 1
# EndMeasurement

BeginMonomial GAUGE
  Type = Iwasaki
  beta = 1.90
  Timescale = 0
EndMonomial

BeginMonomial DET
  Timescale = 1
  2KappaMu = 0.2
  kappa = 0.163255
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 500
  Name = det_d1
  UseExternalInverter = QUDA
  solver = cg
  usesloppyprecision = half
EndMonomial

BeginMonomial DET
  Timescale = 1
  2KappaMu = 0.2
  kappa = 0.163255
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 500
  Name = det_d2
  UseExternalInverter = QUDA
  solver = cg
  usesloppyprecision = half
EndMonomial

BeginMonomial DETRATIO
  Timescale = 2
  2KappaMu = 0.02
  kappa = 0.163255
  2KappaMu2 = 0.2
  kappa2 = 0.163255
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 2000
  Name = detratio1_d1
  UseExternalInverter = QUDA
  solver = cg
  usesloppyprecision = half
EndMonomial

BeginMonomial DETRATIO
  Timescale = 2
  2KappaMu = 0.02
  kappa = 0.163255
  2KappaMu2 = 0.2
  kappa2 = 0.163255
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 2000
  Name = detratio1_d2
  UseExternalInverter = QUDA
  solver = cg
  usesloppyprecision = half
EndMonomial

BeginMonomial DETRATIO
  Timescale = 3
  2KappaMu = 0.002
  kappa = 0.163255
  2KappaMu2 = 0.02
  kappa2 = 0.163255
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 10000
  Name = detratio2_d1
  UseExternalInverter = QUDA
  Solver = mg
  UseSloppyPrecision = single
EndMonomial

BeginMonomial DETRATIO
  Timescale = 3
  2KappaMu = 0.002
  kappa = 0.163255
  2KappaMu2 = 0.02
  kappa2 = 0.163255
  AcceptancePrecision =  1e-20
  ForcePrecision = 1e-15
  MaxSolverIterations = 10000
  Name = detratio2_d2
  UseExternalInverter = QUDA
  Solver = mg
  UseSloppyPrecision = single
EndMonomial

BeginIntegrator 
  Type0 = 2MN
  Type1 = 2MN
  Type2 = 2MN
  Type3 = 2MN
  IntegrationSteps0 = 1
  IntegrationSteps1 = 1
  IntegrationSteps2 = 1 
  IntegrationSteps3 = 10
  Tau = 1.0
  Lambda0 = 0.19
  Lambda1 = 0.20
  Lambda2 = 0.205
  Lambda3 = 0.210
  NumberOfTimescales = 4
EndIntegrator
```