### PR TITLE
single-flavour RHMC using QUDA's mutltishift solver

### DIFF
--- a/operator/clovertm_operators.c
+++ b/operator/clovertm_operators.c
@@ -243,6 +243,12 @@ void Qsw_pm_psi(spinor * const l, spinor * const k) {
   clover_gamma5(OO, l, g_spinor_field[DUM_MATRIX], g_spinor_field[DUM_MATRIX+1], +(g_mu + g_mu3));
 }
 
+void Qsw_pm_psi_shift(spinor * const l, spinor * const k){
+  Qsw_pm_psi(l,k);  
+  assign_add_mul_r(l, k, g_shift, VOLUME/2);
+  return;
+}
+
 // this is the clover Mhat with mu = 0
 void Msw_psi(spinor * const l, spinor * const k) {
   Hopping_Matrix(EO, g_spinor_field[DUM_MATRIX+1], k);

--- a/operator/clovertm_operators.h
+++ b/operator/clovertm_operators.h
@@ -62,6 +62,7 @@ void Qsw_plus_psi(spinor * const l, spinor * const k);
 void Qsw_minus_psi(spinor * const l, spinor * const k);
 void Qsw_sq_psi(spinor * const l, spinor * const k);
 void Qsw_pm_psi(spinor * const l, spinor * const k);
+void Qsw_pm_psi_shift(spinor * const l, spinor * const k);
 void Msw_psi(spinor * const l, spinor * const k);
 void Msw_plus_psi(spinor * const l, spinor * const k);
 void Msw_minus_psi(spinor * const l, spinor * const k);

--- a/operator/tm_operators.c
+++ b/operator/tm_operators.c
@@ -344,6 +344,12 @@ void Qtm_pm_psi(spinor * const l, spinor * const k){
   tm_sub_H_eo_gamma5(l, g_spinor_field[DUM_MATRIX], g_spinor_field[DUM_MATRIX+1], OE, +1);
 }
 
+void Qtm_pm_psi_shift(spinor * const l, spinor * const k){
+  Qtm_pm_psi(l,k);  
+  assign_add_mul_r(l, k, g_shift, VOLUME/2);
+  return;
+}
+
 void Qtm_pm_sym_psi(spinor * const l, spinor * const k){
   /* Q_{-} */
   Hopping_Matrix(EO, g_spinor_field[DUM_MATRIX+1], k);

--- a/operator/tm_operators.h
+++ b/operator/tm_operators.h
@@ -38,6 +38,7 @@ void Mtm_plus_psi(spinor * const l, spinor * const k);
 void Mtm_plus_psi_nocom(spinor * const l, spinor * const k);
 void Mtm_minus_psi(spinor * const l, spinor * const k);
 void Qtm_pm_psi(spinor * const l, spinor * const k);
+void Qtm_pm_psi_shift(spinor * const l, spinor * const k);
 void Qtm_pm_psi_nocom(spinor * const l, spinor * const k);
 void H_eo_tm_inv_psi(spinor * const l, spinor * const k, const int ieo, const double sign);
 void mul_one_pm_imu_inv(spinor * const l, const double _sign, const int N);

--- a/quda_interface.c
+++ b/quda_interface.c
@@ -1358,6 +1358,7 @@ void _setOneFlavourSolverParam(const double kappa, const double c_sw, const doub
       
       inv_param.preconditioner = quda_mg_preconditioner;
       set_quda_mg_setup_state(&quda_mg_setup_state, &quda_gauge_state);
+      set_quda_mg_setup_init_gauge_id(&quda_mg_setup_state, &quda_gauge_state);
       tm_debug_printf(0,1,"# TM_QUDA: MG Preconditioner Setup took %.3f seconds\n", gettime()-atime);
     } else if ( check_quda_mg_setup_state(&quda_mg_setup_state, &quda_gauge_state, &quda_input) == TM_QUDA_MG_SETUP_UPDATE )  {
       tm_debug_printf(0,0,"# TM_QUDA: Updating MG Preconditioner Setup for gauge %f\n", quda_gauge_state.gauge_id);

--- a/quda_interface.h
+++ b/quda_interface.h
@@ -149,5 +149,12 @@ int invert_eo_MMd_quda( spinor * const Odd_new,
                    CompressionType compression,
                    const int QmQp);
 
+int invert_eo_quda_oneflavour_mshift(spinor ** const Odd_new,
+                                     spinor * const Odd,
+                                     const double precision, const int max_iter,
+                                     const int solver_flag, const int rel_prec,
+                                     const int even_odd_flag, solver_params_t solver_params,
+                                     const SloppyPrecision sloppy_precision,
+                                     CompressionType compression);
 
 #endif /* QUDA_INTERFACE_H_ */

--- a/quda_types.h
+++ b/quda_types.h
@@ -111,6 +111,7 @@ typedef struct tm_QudaParams_t {
 } tm_QudaParams_t;
 
 typedef struct tm_QudaMGSetupState_t {
+  double init_gauge_id;
   double gauge_id;
   double c_sw;
   double kappa;
@@ -219,7 +220,8 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
       ( fabs(quda_mg_setup_state->theta_y - quda_gauge_state->theta_y) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_z - quda_gauge_state->theta_z) > 2*DBL_EPSILON ) || 
       ( fabs(quda_mg_setup_state->theta_t - quda_gauge_state->theta_t) > 2*DBL_EPSILON ) || 
-      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) > quda_params->mg_reset_setup_threshold ) ){
+      ( fabs(quda_mg_setup_state->gauge_id - quda_gauge_state->gauge_id) > quda_params->mg_reset_setup_threshold ) ||
+      ( fabs(quda_mg_setup_state->init_gauge_id - quda_gauge_state->gauge_id) > quda_params->mg_reset_setup_threshold ) ){
     return TM_QUDA_MG_SETUP_RESET;
   // in other cases, e.g., when the operator parameters change or if the gauge_id has "moved" only a little,
   // we don't need to redo the setup, we can simply rebuild the coarse operators with the
@@ -238,6 +240,11 @@ static inline int check_quda_mg_setup_state(const tm_QudaMGSetupState_t * const 
   }
 }
 
+static inline void set_quda_mg_setup_init_gauge_id(tm_QudaMGSetupState_t * const quda_mg_setup_state,
+                                                   const tm_QudaGaugeState_t * const quda_gauge_state){
+  quda_mg_setup_state->init_gauge_id = quda_gauge_state->gauge_id;
+}
+
 static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg_setup_state,
                                            const tm_QudaGaugeState_t * const quda_gauge_state){
   quda_mg_setup_state->gauge_id = quda_gauge_state->gauge_id;
@@ -252,6 +259,7 @@ static inline void set_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg
 }
 
 static inline void reset_quda_mg_setup_state(tm_QudaMGSetupState_t * const quda_mg_setup_state){
+  quda_mg_setup_state->init_gauge_id = -1;
   quda_mg_setup_state->gauge_id = -1;
   quda_mg_setup_state->initialised = 0;
   quda_mg_setup_state->mu = -1.0;

--- a/update_momenta_fg.c
+++ b/update_momenta_fg.c
@@ -230,7 +230,7 @@ void update_momenta_fg(int * mnllist, double step, const int no,
 
   etime = gettime();
   if(g_debug_level > 1 && g_proc_id == 0) {
-    printf("# Time gauge update: %e s\n", etime-atime); 
+    printf("# Time force-gradient gauge update: %e s\n", etime-atime); 
   } 
   return;
 }


### PR DESCRIPTION
 - Add support for single-flavour RHMC using the QUDA multi-shift solver (Wilson and Wilson-clover only).
- Finally fix the solve_mms_tm residual check in the process.
- FIXME: For Wilson-clover, there is still a precision mismatch problem which crashes the run at the end of the heatbath step. This likely has to do with the fact that when the clover term is used and we switch precision, we need to reissue the clover load.

When we fix the FIXME above, this will likely also resolve our issues with cloverdet precision mismatches.